### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@types/node": "22.12.0",
         "jest": "29.7.0",
         "prettier": "3.4.2",
+        "ts-node": "^10.9.2",
         "typescript": "5.7.3"
     }
 }


### PR DESCRIPTION
When running tests for first problem i encountered following error.
Adding `ts-node` to the dependencies fixed the issue.

`
npm run test1

> tact-smart-battle@0.0.1 test1
> tact -c tact.config.json --project solution1 && jest --verbose public1

💼 Compiling project solution1 ...
   > Proposal: tact compiler
   > Proposal: func compiler
   > Packaging
   > Proposal
   > Bindings
   > Proposal
   > Reports
   > Proposal
Error: Jest: Failed to parse the TypeScript config file C:\Users\...\tact-smart-battle\jest.config.ts
  Error: Jest: 'ts-node' is required for the TypeScript configuration files. Make sure it is installed
Error: Cannot find package 'ts-node' imported from C:\Users\...\tact-smart-battle\node_modules\jest-config\build\readConfigFileAndSetRootDir.js
    at readConfigFileAndSetRootDir (C:\Users\...\tact-smart-battle\node_modules\jest-config\build\readConfigFileAndSetRootDir.js:116:13)
    at async readInitialOptions (C:\Users\...\tact-smart-battle\node_modules\jest-config\build\index.js:403:13)
    at async readConfig (C:\Users\...\tact-smart-battle\node_modules\jest-config\build\index.js:147:48)
    at async readConfigs (C:\Users\...\tact-smart-battle\node_modules\jest-config\build\index.js:424:26)
    at async runCLI (C:\Users\...\tact-smart-battle\node_modules\@jest\core\build\cli\index.js:151:59)
    at async Object.run (C:\Users\...\tact-smart-battle\node_modules\jest-cli\build\run.js:130:37)
    `